### PR TITLE
Fix eslint error and adding copy-config scripts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "es2021": true,
     "node": true
@@ -14,12 +15,23 @@
   },
   "settings": {
     "import/parsers": {
-      "@typescript-eslint/parser": [".ts", ".tsx"]
+      "@typescript-eslint/parser": [
+        ".ts",
+        ".tsx"
+      ]
     },
     "import/resolver": {
       "node": {
-        "extensions": [".js", ".jsx", ".ts", ".tsx"],
-        "moduleDirectory": ["node_modules", "src/"]
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx"
+        ],
+        "moduleDirectory": [
+          "node_modules",
+          "src/"
+        ]
       },
       "typescript": {
         "alwaysTryTypes": true
@@ -37,12 +49,20 @@
     "plugin:prettier/recommended",
     "plugin:react-hooks/recommended"
   ],
-  "plugins": ["react", "prettier", "import"],
+  "plugins": [
+    "react",
+    "prettier",
+    "import"
+  ],
   "rules": {
     "import/order": [
       "warn",
       {
-        "groups": ["builtin", "external", "internal"],
+        "groups": [
+          "builtin",
+          "external",
+          "internal"
+        ],
         "pathGroups": [
           {
             "pattern": "react",
@@ -50,7 +70,9 @@
             "position": "before"
           }
         ],
-        "pathGroupsExcludedImportTypes": ["react"],
+        "pathGroupsExcludedImportTypes": [
+          "react"
+        ],
         "newlines-between": "ignore",
         "alphabetize": {
           "order": "asc",
@@ -73,9 +95,18 @@
     "@typescript-eslint/no-non-null-assertion": "off",
     "react/prop-types": "off",
     "react/display-name": "off",
-    "linebreak-style": ["error", "unix"],
-    "quotes": ["error", "single"],
-    "semi": ["error", "always"],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
     "object-curly-newline": "off",
     "arrow-body-style": "off",
     "react/jsx-props-no-spreading": "off",
@@ -89,7 +120,9 @@
     "react/jsx-wrap-multilines": "off",
     "react/destructuring-assignment": "off",
     "no-shadow": "off",
-    "@typescript-eslint/no-shadow": ["warn"],
+    "@typescript-eslint/no-shadow": [
+      "warn"
+    ],
     "react/no-array-index-key": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "yup": "0.32.9"
   },
   "scripts": {
+    "copy-devnet-config": "cp ./src/config.devnet.ts ./src/config.ts",
+    "copy-testnet-config": "cp ./src/config.testnet.ts ./src/config.ts",
+    "copy-mainnet-config": "cp ./src/config.mainnet.ts ./src/config.ts",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint --ext ts,tsx src"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
- Recently I always get the error `Failed to load config "standard" to extend from` when not including `root: true` in the eslint config. I'm not 100% sure if that is due to my faulty eslint installation. If so, then sorry! But with `root: true` it works and it shouldn't break functionalities to include it.
- Convenience scripts to copy the devnet/testnet/mainnet config into `config.tsx` have been added to `package.json`
- Lint script added to `package.json`