### PR TITLE
fail in getIsContractTrusted when address is undefined

### DIFF
--- a/src/apiCalls/multisigContractsCalls.ts
+++ b/src/apiCalls/multisigContractsCalls.ts
@@ -65,7 +65,7 @@ export async function validateMultisigAddress(address: string) {
 
 export async function getIsContractTrusted(address?: string) {
   try {
-    if (address == null) {
+    if (!address) {
       return false;
     }
     const response = await axios.get(


### PR DESCRIPTION
In the `getIsContractTrusted` function, `address` is set as optional parameter. So when not set, its value will be `undefined` (not `null`).

The guard in the first line however explicitely checks for `null` value. Hence, when the address is not passed (hence `undefined`), the guard will not return early, but instead an axios call will happen.

I believe that it is smart to early return when the address is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy).

If you **purposely** checked only for null, just ignore this PR!